### PR TITLE
fix: make sure package is loaded

### DIFF
--- a/tests/testthat/helper-01-library.R
+++ b/tests/testthat/helper-01-library.R
@@ -1,0 +1,5 @@
+# Load needed packages
+suppressPackageStartupMessages({
+  library("testthat")
+  library("zephyr")
+})


### PR DESCRIPTION
In order to get the test to run in the azure pipeline the used libraries must be called