### PR TITLE
feat: initial CRAN release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,5 @@
 ^.pre-commit-config\.yaml$
+^CRAN-SUBMISSION$
 ^LICENSE\.md$
 ^README\.Rmd$
 ^\.Rproj\.user$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
           .*\.svg|
           .*\.ico|
           .*\.webmanifest|
+          CRAN-SUBMISSION|
           )$
     # -   id: lintr
     -   id: readme-rmd-rendered

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.1.0
+Date: 2025-01-16 13:15:10 UTC
+SHA: 60fd02b373bbf50ba531af1f63f5f84cc3f04c36

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,0 @@
-Version: 0.1.0
-Date: 2025-01-16 13:15:10 UTC
-SHA: 60fd02b373bbf50ba531af1f63f5f84cc3f04c36

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zephyr
 Title: Structured Messages and Options
-Version: 0.0.5
+Version: 0.1.0
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Mathias Lerbech", "Jeppesen", , "nmlj@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# zephyr 0.0.4.9000
+# zephyr 0.1.0
 
 * Initial release to CRAN.
-* Tools for writing messages based on `verbosity_level`.
+* Provides a structured framework for consistent user communication and 
+configuration management for package developers.


### PR DESCRIPTION
# zephyr 0.1.0 released on CRAN

* Available on CRAN: https://cran.r-project.org/package=zephyr
* GitHub release: https://github.com/NovoNordisk-OpenSource/zephyr/releases/tag/v0.1.0