### PR TITLE
fix: list_options() and get_option()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zephyr
 Title: Structured Messages and Options
-Version: 0.1.9000
+Version: 0.1.0.9000
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Mathias Lerbech", "Jeppesen", , "nmlj@novonordisk.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zephyr
 Title: Structured Messages and Options
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Mathias Lerbech", "Jeppesen", , "nmlj@novonordisk.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zephyr
 Title: Structured Messages and Options
-Version: 0.1.1
+Version: 0.1.9000
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Mathias Lerbech", "Jeppesen", , "nmlj@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# zephyr 0.1.1
+
+* Fixes a bug where `list_options()` was being able to document options with 
+non vector default values, or with length different from one.
+* `get_option()` now gives consistent return for non vector options, 
+e.g. functions.
+
 # zephyr 0.1.0
 
 * Initial release to CRAN.

--- a/R/options.R
+++ b/R/options.R
@@ -179,7 +179,7 @@ list_options <- function(as = c("list", "params", "markdown"),
       vapply(
         FUN = glue::glue_data,
         FUN.VALUE = character(1),
-        "@param {name} {description}. Default: `{default}`.",
+        "@param {name} {description}. Default: `{deparse1(default)}`.",
         USE.NAMES = FALSE
       ),
     "markdown" = options |>
@@ -189,7 +189,7 @@ list_options <- function(as = c("list", "params", "markdown"),
         "
         ## {name}
         {description}
-        * Default: `{default}`
+        * Default: `{deparse1(default)}`
         * Option: `{tolower(environment)}.{name}`
         * Environment: `R_{toupper(environment)}_{toupper(name)}`
         ",

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,7 +34,10 @@ fix_env_class <- function(x, default = x) {
   if (is.null(x) || is.null(default) ||
         isTRUE(all.equal(class(x), class(default)))) {
     return(x)
+  } else if (is.character(x) && !is.vector(default)) {
+    return(eval(parse(text = x)))
   }
+
   if (is.character(x) && is.logical(default)) {
     x <- toupper(x)
     x[x %in% c("Y", "YES", "T")] <- "TRUE"
@@ -49,7 +52,7 @@ coalesce_dots <- function(...) {
   dots <- rlang::list2(...)
   for (i in seq_along(dots)) {
     dot <- dots[[i]]
-    if (!is.null(dot) && !all(is.na(dot))) {
+    if (!is.null(dot) && (!is.vector(dot) || !all(is.na(dot)))) {
       return(dot)
     }
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,7 @@
+# nocov start
 .onLoad <- function(...) {
   s3_register("base::format", "zephyr_option")
   s3_register("base::print", "zephyr_option")
   s3_register("base::print", "zephyr_options")
 }
+# nocov end

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -68,6 +68,7 @@ nocov
 novonordisk
 oldrel
 opensource
+params
 pkgdown
 pkgload
 pkgname

--- a/tests/testthat/_snaps/options.md
+++ b/tests/testthat/_snaps/options.md
@@ -76,11 +76,78 @@
 ---
 
     Code
+      print(expect_length(expect_s3_class(list_options(.envir = testenv),
+      "zephyr_options"), 5))
+    Output
+      
+      -- verbosity_level 
+      Dummy verbosity in this package
+      * Default: `NA_character_`
+      * Option: `testenv.verbosity_level`
+      * Environment: `R_TESTENV_VERBOSITY_LEVEL`
+      
+      -- test_option 
+      test_option
+      * Default: `42`
+      * Option: `testenv.test_option`
+      * Environment: `R_TESTENV_TEST_OPTION`
+      
+      -- test_null 
+      test_null
+      * Default: `NULL`
+      * Option: `testenv.test_null`
+      * Environment: `R_TESTENV_TEST_NULL`
+      
+      -- test_long 
+      test_long
+      * Default: `c("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+      "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z")`
+      * Option: `testenv.test_long`
+      * Environment: `R_TESTENV_TEST_LONG`
+      
+      -- test_func 
+      test_func
+      * Default: `function (x) x + 1`
+      * Option: `testenv.test_func`
+      * Environment: `R_TESTENV_TEST_FUNC`
+
+# list_options - as params
+
+    Code
       print(expect_length(expect_type(list_options(as = "params", .envir = testenv),
       "character"), 2))
     Output
-      [1] "@param verbosity_level Dummy verbosity in this package. Default: `NA`."
-      [2] "@param test_option test_option. Default: `42`."                        
+      [1] "@param verbosity_level Dummy verbosity in this package. Default: `NA_character_`."
+      [2] "@param test_option test_option. Default: `42`."                                   
+
+---
+
+    Code
+      print(expect_length(expect_type(list_options(as = "params", .envir = testenv),
+      "character"), 5))
+    Output
+      [1] "@param verbosity_level Dummy verbosity in this package. Default: `NA_character_`."                                                                                                                                              
+      [2] "@param test_option test_option. Default: `42`."                                                                                                                                                                                 
+      [3] "@param test_null test_null. Default: `NULL`."                                                                                                                                                                                   
+      [4] "@param test_long test_long. Default: `c(\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\", \"i\", \"j\", \"k\", \"l\", \"m\", \"n\", \"o\", \"p\", \"q\", \"r\", \"s\", \"t\", \"u\", \"v\", \"w\", \"x\", \"y\", \"z\")`."
+      [5] "@param test_func test_func. Default: `function (x)  x + 1`."                                                                                                                                                                    
+
+# list_options - as markdown
+
+    Code
+      cat(expect_length(expect_type(list_options(as = "markdown", .envir = testenv),
+      "character"), 1))
+    Output
+      ## verbosity_level
+      Dummy verbosity in this package
+      * Default: `NA_character_`
+      * Option: `testenv.verbosity_level`
+      * Environment: `R_TESTENV_VERBOSITY_LEVEL`
+      ## test_option
+      test_option
+      * Default: `42`
+      * Option: `testenv.test_option`
+      * Environment: `R_TESTENV_TEST_OPTION`
 
 ---
 
@@ -90,7 +157,7 @@
     Output
       ## verbosity_level
       Dummy verbosity in this package
-      * Default: `NA`
+      * Default: `NA_character_`
       * Option: `testenv.verbosity_level`
       * Environment: `R_TESTENV_VERBOSITY_LEVEL`
       ## test_option
@@ -98,4 +165,19 @@
       * Default: `42`
       * Option: `testenv.test_option`
       * Environment: `R_TESTENV_TEST_OPTION`
+      ## test_null
+      test_null
+      * Default: `NULL`
+      * Option: `testenv.test_null`
+      * Environment: `R_TESTENV_TEST_NULL`
+      ## test_long
+      test_long
+      * Default: `c("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z")`
+      * Option: `testenv.test_long`
+      * Environment: `R_TESTENV_TEST_LONG`
+      ## test_func
+      test_func
+      * Default: `function (x)  x + 1`
+      * Option: `testenv.test_func`
+      * Environment: `R_TESTENV_TEST_FUNC`
 

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -48,6 +48,45 @@ test_that("get_option", {
     expect_error()
 })
 
+test_that("get_option - advanced use cases", {
+  testenv <- simulate_package_env("testenv")
+  create_option(name = "test_null", default = NULL, .envir = testenv)
+  create_option(name = "test_long", default = letters, .envir = testenv)
+  create_option(name = "test_func", default = \(x) x + 1, .envir = testenv)
+
+  get_option("test_null", .envir = testenv) |>
+    expect_null()
+
+  withr::with_options(c(testenv.test_null = 200), {
+    get_option("test_null", .envir = testenv) |>
+      expect_equal(200)
+  })
+
+  get_option("test_long", .envir = testenv) |>
+    expect_equal(letters)
+
+  withr::with_envvar(c(R_TESTENV_TEST_LONG = "a;b;c;d;e;f;g;h"), {
+    get_option("test_long", .envir = testenv) |>
+      expect_equal(c("a", "b", "c", "d", "e", "f", "g", "h"))
+  })
+
+  f <- get_option("test_func", .envir = testenv)
+  expect_true(is.function(f))
+  expect_equal(f(1), 2)
+
+  withr::with_envvar(c(R_TESTENV_TEST_FUNC = "function(x) x + 2"), {
+    f <- get_option("test_func", .envir = testenv)
+    expect_true(is.function(f))
+    expect_equal(f(1), 3)
+  })
+
+  withr::with_options(c(testenv.test_func = \(x) x + 10), {
+    f <- get_option("test_func", .envir = testenv)
+    expect_true(is.function(f))
+    expect_equal(f(1), 11)
+  })
+})
+
 test_that("zephyr options", {
   list_options(.envir = "zephyr") |>
     expect_s3_class("zephyr_options") |>
@@ -65,9 +104,19 @@ test_that("list_options - as list", {
     expect_length(2) |>
     print() |>
     expect_snapshot()
+
+  create_option(name = "test_null", default = NULL, .envir = testenv)
+  create_option(name = "test_long", default = letters, .envir = testenv)
+  create_option(name = "test_func", default = \(x) x + 1, .envir = testenv)
+
+  list_options(.envir = testenv) |>
+    expect_s3_class("zephyr_options") |>
+    expect_length(5) |>
+    print() |>
+    expect_snapshot()
 })
 
-test_that("list_options - as list", {
+test_that("list_options - as params", {
   testenv <- simulate_package_env("testenv")
   create_option(name = "test_option", default = 42, .envir = testenv)
 
@@ -76,11 +125,31 @@ test_that("list_options - as list", {
     expect_length(2) |>
     print() |>
     expect_snapshot()
+
+  create_option(name = "test_null", default = NULL, .envir = testenv)
+  create_option(name = "test_long", default = letters, .envir = testenv)
+  create_option(name = "test_func", default = \(x) x + 1, .envir = testenv)
+
+  list_options(as = "params", .envir = testenv) |>
+    expect_type("character") |>
+    expect_length(5) |>
+    print() |>
+    expect_snapshot()
 })
 
-test_that("list_options - as list", {
+test_that("list_options - as markdown", {
   testenv <- simulate_package_env("testenv")
   create_option(name = "test_option", default = 42, .envir = testenv)
+
+  list_options(as = "markdown", .envir = testenv) |>
+    expect_type("character") |>
+    expect_length(1) |>
+    cat() |>
+    expect_snapshot()
+
+  create_option(name = "test_null", default = NULL, .envir = testenv)
+  create_option(name = "test_long", default = letters, .envir = testenv)
+  create_option(name = "test_func", default = \(x) x + 1, .envir = testenv)
 
   list_options(as = "markdown", .envir = testenv) |>
     expect_type("character") |>


### PR DESCRIPTION
# Fix missing use cases from whirl

This PR fixes some edge cases with options that were not supported, but needed inside whirl:
* Fixes a bug where `list_options()` was being able to document options with 
non vector default values, or with length different from one.
* `get_option()` now gives consistent return for non vector options, 
e.g. functions.

See this whirl actions run where they have been successfully implemented: https://github.com/NovoNordisk-OpenSource/whirl/actions/runs/12949549610/job/36120507515?pr=131

I left this PR with version 0.1.0.9000, but will bump to 0.1.1 after this has been merged, and submit to CRAN thereafter.